### PR TITLE
Added #include guards to header file

### DIFF
--- a/LPD8806.h
+++ b/LPD8806.h
@@ -1,3 +1,6 @@
+#ifndef LPD8806_H
+#define LPD8806_H
+
 #if (ARDUINO >= 100)
  #include <Arduino.h>
 #else
@@ -44,3 +47,4 @@ class LPD8806 {
     hardwareSPI, // If 'true', using hardware SPI
     begun;       // If 'true', begin() method was previously invoked
 };
+#endif


### PR DESCRIPTION
This prevents problems arising from double inclusion (redefining of the LPD8806 class) when it is imported multiple times (because the main sketch and a support library include it)

Alternatively `#pragma once` could be used, but as it's non-standard there -might- be compilers where it is not supported. GCC has good support for `#pragma once` though.
