### PR TITLE
[#23] Add missing word "in" and quote library path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Or follow [this](https://github.com/adafruit/LPD8806/zipball/master) link
 * Uncompress the Downloaded Library
 * Rename the uncompressed folder to LPD8806
 * Check that the LPD8806 folder contains LPD8806.cpp and LPD8806.h
-* Place the LPD8806 library folder your <arduinosketchfolder>/libraries/ folder, 
+* Place the LPD8806 library folder in your `<arduinosketchfolder>/libraries/` folder,
   if the libraries folder does not exist - create it first!
 * Restart the IDE


### PR DESCRIPTION
The second to last installation step is missing the word "in"
before " your <arduinosketchfolder>/libraries/ folder,".
The "<arduinosketchfolder>" will not show properly in rendered
Markdown because  '<' is the start of an HTML tag. Enclosing this
in backticks fixes it. Alternatively, the less than and greater than
symbols could be HTML encoded, but this does not look as clean in the
raw Markdown text.